### PR TITLE
Remove trailing slash from frontend axios

### DIFF
--- a/frontend/src/views/home/Search.vue
+++ b/frontend/src/views/home/Search.vue
@@ -71,7 +71,7 @@ export default class Search extends Vue {
     evt.preventDefault();
     let res = this;
     axios
-      .post(`${apiUrl}/api/v1/redirect/checker/`, {
+      .post(`${apiUrl}/api/v1/redirect/checker`, {
         url: this.form.url,
       })
       .then((resp) => {


### PR DESCRIPTION
# HOTFIX

API fails to return anything

## Cause

`https://check-redirects.com/api/v1/redirect/checker/` does not follow a redirect to `https://check-redirects.com/api/v1/redirect/checker`. 

In development, the endpoint with a trailing slash will redirect correctly.

## Fix

Trailing slash removed in the frontend component `Search.vue`



